### PR TITLE
Handle extra-quoted arguments to condor_submit.sh (SOFTWARE-3993)

### DIFF
--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -228,8 +228,11 @@ fi
 # # so to get them back into Condor format we need to remove all the
 # # extra quotes. We do this by replacing '" "' with ' ' and stripping
 # # the leading and trailing "s.
-# arguments="$(echo $arguments | sed -e 's/\" \"/ /g')"
-# arguments=${arguments:1:$((${#arguments}-2))}
+if [[ $arguments = '"'*'"' ]]; then
+  arguments=${arguments//'" "'/ }
+  arguments=${arguments/#'"'}
+  arguments=${arguments/%'"'}
+fi
 
 cat > $submit_file << EOF
 universe = vanilla


### PR DESCRIPTION
https://support.opensciencegrid.org/a/tickets/64347

Lincoln encountered errors at SLATE / UIUC where arguments were
being passed to condor_submit.sh as one long argument to the script,
with each embedded argument in the arguments string also quoted with
a level of double-quotes.  eg, `'"arg1" "arg2" "arg3"'`

Existing comments in condor_submit.sh suggest that this issue may
have been know about in the past, but for whatever reason was not
an issue -- evidenced by the previously-commented-out sed commands
that removed the extra `'" "'` quoting.

It's not yet clear what triggered the issue at SLATE / UIUC, so if
more details are uncovered we may yet come up with a better solution.

But for the time being this handles the case where args to
condor_submit.sh just have an extra (redundant) level of double-
quotes around each embedded argument.