### PR TITLE
expand env vars in configured slurm_binpath

### DIFF
--- a/src/scripts/slurm_status.py
+++ b/src/scripts/slurm_status.py
@@ -398,7 +398,7 @@ def get_slurm_location(program):
     slurm_bindir = env_expand(config.get('slurm_binpath'))
     slurm_bin_location = os.path.join(slurm_bindir, program)
     if not os.path.exists(slurm_bin_location):
-        raise Exception("Could not find %s in slurm_binpath=%s" % (program, output))
+        raise Exception("Could not find %s in slurm_binpath=%s" % (program, slurm_bindir))
     _slurm_location_cache = slurm_bindir
     return slurm_bin_location
 

--- a/src/scripts/slurm_status.py
+++ b/src/scripts/slurm_status.py
@@ -379,7 +379,12 @@ def get_finished_job_stats(jobid, cluster):
                 log("Failed to parse memory usage for job id %s: %s" % (jobid, row["MaxRSS"]))
                 raise
     return return_dict
-    
+
+def env_expand(path):
+    """ substitute occurences of $VAR or ${VAR} in path """
+    def envmatch(m):
+        return os.getenv(m.group(1) or m.group(2)) or ""
+    return re.sub(r'\$(?:{(\w+)}|(\w+))', envmatch, path)
 
 _slurm_location_cache = None
 def get_slurm_location(program):
@@ -390,7 +395,7 @@ def get_slurm_location(program):
     if _slurm_location_cache is not None:
         return os.path.join(_slurm_location_cache, program)
 
-    slurm_bindir = config.get('slurm_binpath')
+    slurm_bindir = env_expand(config.get('slurm_binpath'))
     slurm_bin_location = os.path.join(slurm_bindir, program)
     if not os.path.exists(slurm_bin_location):
         raise Exception("Could not find %s in slurm_binpath=%s" % (program, output))


### PR DESCRIPTION
Per discussion in #9, we want to restore the previous functionality
that shell vars within the configured slurm_binpath would get
expanded.

It was a bit unsettling that it was shelling out to run `echo "%s/%s"`
to get the result, first because it seemed kind of roundabout, but
also unsettlingly because in theory backtick expansions get performed
and can run arbitrary commands.  Also interestingly, a config value
that contains doublequotes can do some interesting things to get shell
glob wildcard characters to expand, add redirection characters to
clobber arbitrary files, and add semicolons to start arbitrary new
command lines.  But, depending on your point of view, that could all
be "a feature not a bug."  Haha.

Anyway, here, instead, we do a simple substitution of anything that
looks like a shell variable, namely any occurrences of $VAR and ${VAR}

No attempt to do any sort of quoting or backslash escaping is done,
because (1) that's easy to get wrong, and (2) i hope it's reasonable
to bet that people's slurm binpaths do not contain dollar signs or
backslashes.