### PR TITLE
fix cluster handling in slurm_status.py

### DIFF
--- a/src/scripts/slurm_status.py
+++ b/src/scripts/slurm_status.py
@@ -232,12 +232,13 @@ def call_scontrol(jobid="", cluster=""):
     Returns a python dictionary with the job info.
     """
     scontrol = get_slurm_location('scontrol')
-    if cluster != "":
-        scontrol += " -M %s" % cluster
 
     starttime = time.time()
     log("Starting scontrol.")
-    command = (scontrol, 'show', 'job')
+    if cluster:
+        command = (scontrol, '-M', cluster, 'show', 'job')
+    else:
+        command = (scontrol, 'show', 'job')
     if jobid:
         command += (jobid,)
     scontrol_proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)


### PR DESCRIPTION
it seems that adding the "-M <cluster>" to the scontrol command will
be treated as part of the path to the scontrol executable, rather than
as part of the command line, since command is passed into Popen as a
tuple, not a string.

Noticed this while looking over #5 