### PR TITLE
add EXIT trap to remove barrier file (SOFTWARE-3930)

### DIFF
--- a/src/scripts/condor_status.sh
+++ b/src/scripts/condor_status.sh
@@ -213,6 +213,12 @@ function make_ad {
     echo "]"
 }
 
+function at_exit {
+    local cache=$(identify_cache $queue $pool)
+    rm -f "$cache.barrier"
+}
+trap at_exit EXIT
+
 ### main
 
 while getopts "wn" arg 


### PR DESCRIPTION
Marco Mascheroni reported that a stale barrier file would sometimes
get left behind and cause problems if the condor_status.sh script
was killed (with SIGTERM).  He found that adding an EXIT trap to
clean up the barrier file resolved the issue for him.

I actually hate with a good deal of hate the current "barrier" file
locking implementation, and by adding this band-aid, i do not mean
to imply approval of the rest of the barrier file implementation.

But this does give an incremental improvement and seems to resolve the
issue Marco was encountering, so we'll go with it.

But yeah, at some point i would feel better about the barrier lockfile
thing in general if it was thought through a lot more carefully, with
an eye for race conditions, etc.