### PR TITLE
Add condor_submit debugging, et c. (SOFTWARE-3994)

### DIFF
--- a/src/scripts/blah_common_submit_functions.sh
+++ b/src/scripts/blah_common_submit_functions.sh
@@ -451,10 +451,8 @@ function bls_setup_all_files ()
           fi 
           bls_tmp_file="$bls_opt_temp_dir/$bls_tmp_name"
       else
-          rand=`od -A n -t xC -N 6 /dev/urandom`
-          bls_tmp_name=bl_${rand// /}
-          bls_tmp_file="$bls_opt_temp_dir/$bls_tmp_name"
-          `touch $bls_tmp_file;chmod 600 $bls_tmp_file`
+          bls_tmp_file=$(mktemp "$bls_opt_temp_dir/bl_XXXXXX") &&
+          bls_tmp_name=${bls_tmp_file##*/}
       fi
       if [ $? -ne 0 ]; then
           echo Error

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -70,9 +70,9 @@ if [ ! -z "$bls_opt_inputflstring" ] ; then
     done
 fi
 
-if [ ! -z "$outputflstring" ] ; then
+if [ ! -z "$bls_opt_outputflstring" ] ; then
     i=0
-    for file in `cat $outputflstring`; do
+    for file in `cat $bls_opt_outputflstring`; do
 	output_files[$i]=$file
 	i=$((i+1))
     done

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -78,9 +78,9 @@ if [ ! -z "$bls_opt_outputflstring" ] ; then
     done
 fi
 
-if [ ! -z "$remaps" ] ; then
+if [ ! -z "$bls_opt_outputflstringremap" ] ; then
     i=0
-    for file in `cat $remaps`; do
+    for file in `cat $bls_opt_outputflstringremap`; do
 	remap_files[$i]=$file
 	i=$((i+1))
     done

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -171,9 +171,9 @@ then
   echo "request_memory = $bls_opt_req_mem" >> $submit_file
 fi
 
-if [ "x$runtime" != "x" ]
+if [ "x$bls_opt_runtime" != "x" ]
 then
-  echo "periodic_remove = JobStatus == 2 && time() - JobCurrentStartExecutingDate > $runtime" >> $submit_file
+  echo "periodic_remove = JobStatus == 2 && time() - JobCurrentStartExecutingDate > $bls_opt_runtime" >> $submit_file
 fi
 
 cat >> $submit_file << EOF

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -31,7 +31,7 @@
 # limitations under the License.
 #
 
-. `dirname $0`/blah_load_config.sh
+. `dirname $0`/blah_common_submit_functions.sh
 
 usage_string="Usage: $0 -c <command> [-i <stdin>] [-o <stdout>] [-e <stderr>] [-v <environment>] [-s <yes | no>] [-- command_arguments]"
 

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -240,7 +240,7 @@ if [ "$return_code" == "0" ] ; then
     blahp_jobID="condor/$jobID/$queue/$pool"
 
     if [ "x$job_registry" != "x" ]; then
-      ${blah_sbin_directory}/blah_job_registry_add "$blahp_jobID" "$jobID" 1 $now "$creamjobid" "$bls_opt_proxy_string" 0 "$proxy_subject"
+      ${blah_sbin_directory}/blah_job_registry_add "$blahp_jobID" "$jobID" 1 $now "$creamjobid" "$bls_opt_proxy_string" 0 "$bls_opt_proxy_subject"
     fi
 
     echo "BLAHP_JOBID_PREFIX$blahp_jobID"

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -166,9 +166,9 @@ then
   echo "x509userproxy = $bls_opt_proxy_string" >> $submit_file
 fi
 
-if [ "x$req_mem" != "x" ]
+if [ "x$bls_opt_req_mem" != "x" ]
 then
-  echo "request_memory = $req_mem" >> $submit_file
+  echo "request_memory = $bls_opt_req_mem" >> $submit_file
 fi
 
 if [ "x$runtime" != "x" ]

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -33,15 +33,6 @@
 
 . `dirname $0`/blah_common_submit_functions.sh
 
-usage_string="Usage: $0 -c <command> [-i <stdin>] [-o <stdout>] [-e <stderr>] [-v <environment>] [-s <yes | no>] [-- command_arguments]"
-
-workdir=$PWD
-
-proxy_dir=~/.blah_jobproxy_dir
-
-###############################################################
-# Parse parameters
-###############################################################
 original_args="$@"
 # Note: -s (stage command) s ignored as it is not relevant for Condor.
 
@@ -54,54 +45,9 @@ mpinodes=1
 # Name of local requirements file: currently unused
 req_file=""
 
-while getopts "a:i:o:de:j:n:N:z:h:S:v:V:c:w:x:u:q:r:s:T:I:O:R:C:D:m:A:t:" arg 
-do
-    case "$arg" in
-    a) xtra_args="$OPTARG" ;;
-    i) stdin="$OPTARG" ;;
-    o) stdout="$OPTARG" ;;
-    d) debug="yes" ;;
-    e) stderr="$OPTARG" ;;
-    j) creamjobid="$OPTARG" ;;
-    v) envir="$OPTARG";;
-    V) environment="$OPTARG";;
-    c) command="$OPTARG" ;;
-    n) mpinodes="$OPTARG" ;;
-    N) hostsmpsize="$OPTARG";;
-    z) wholenodes="$OPTARG";;
-    h) hostnumber="$OPTARG";;
-    S) smpgranularity="$OPTARG";;
-    w) workdir="$OPTARG";;
-    x) proxy_file="$OPTARG" ;;
-    u) proxy_subject="$OPTARG" ;;
-    q) queue="$OPTARG" ;;
-    r) dummy_proxyrenew="$OPTARG" ;;
-    s) stgcmd="$OPTARG" ;;
-    T) temp_dir="$OPTARG" ;;
-    I) inputflstring="$OPTARG" ;;
-    O) outputflstring="$OPTARG" ;;
-    R) remaps="$OPTARG" ;;
-    C) req_file="$OPTARG" ;;
-    D) run_dir="$OPTARG" ;;
-    m) req_mem="$OPTARG" ;;
-    A) project="$OPTARG" ;;
-    t) runtime="$OPTARG" ;;
-    -) break ;;
-    ?) echo $usage_string
-       exit 1 ;;
-    esac
-done
-
-shift `expr $OPTIND - 1`
-arguments=$*
 
 
-# Command is mandatory
-if [ "x$command" == "x" ]
-then
-    echo $usage_string
-    exit 1
-fi
+bls_parse_submit_options "$@"
 
 bls_setup_all_files
 

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -40,7 +40,7 @@ original_args="$@"
 bls_opt_debug=no
 
 # number of MPI nodes: interpretted as a core count for vanilla universe
-mpinodes=1
+bls_opt_mpinodes=1
 
 # Name of local requirements file: currently unused
 req_file=""
@@ -177,7 +177,7 @@ then
 fi
 
 cat >> $submit_file << EOF
-request_cpus = $mpinodes
+request_cpus = $bls_opt_mpinodes
 # We insist on new style quoting in Condor
 arguments = $arguments
 input = $stdin

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -180,9 +180,9 @@ cat >> $submit_file << EOF
 request_cpus = $bls_opt_mpinodes
 # We insist on new style quoting in Condor
 arguments = $arguments
-input = $stdin
-output = $stdout
-error = $stderr
+input = $bls_opt_stdin
+output = $bls_opt_stdout
+error = $bls_opt_stderr
 $transfer_input_files
 $transfer_output_files
 $transfer_output_remaps

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -251,6 +251,9 @@ else
     echo Error
 fi
 
+# TODO: Use 'bls_wrap_up_submit' here instead of manual cleanup below.
+#       Won't work currently as proxy symlink setup is subtly different.
+
 # Clean temporary files -- There only temp file is the one we submit
 rm -f $submit_file
 

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -103,24 +103,10 @@ then
     exit 1
 fi
 
-# Move into the IWD so we don't clutter the current working directory.
-curdir=`pwd`
-if [ "x$workdir" == "x" ]; then
-    if [ "x$blah_set_default_workdir_to_home" == "xyes" ]; then
-        workdir=$HOME
-    fi
-fi
-
 bls_setup_all_files
 
-if [ "x$workdir" != "x" ]; then
-    cd $workdir
-    if [ $? -ne 0 ]; then
-	echo "Failed to CD to Initial Working Directory." >&2
-	echo Error # for the sake of waiting fgets in blahpd
-	exit 1
-    fi
-fi
+bls_test_input_files
+
 
 ##############################################################
 # Create submit file

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -136,11 +136,6 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-#  Remove any preexisting submit file
-if [ -f $submit_file ] ; then
-	rm -f $submit_file
-fi
-
 if [ ! -z "$inputflstring" ] ; then
     i=0
     for file in `cat $inputflstring`; do

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -43,7 +43,7 @@ bls_opt_debug=no
 bls_opt_mpinodes=1
 
 # Name of local requirements file: currently unused
-req_file=""
+bls_opt_req_file=""
 
 
 

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -201,6 +201,9 @@ bls_set_up_local_and_extra_args
 
 echo "queue 1" >> $submit_file
 
+
+bls_save_submit
+
 ###############################################################
 # Perform submission
 ###############################################################

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -240,11 +240,6 @@ then
   echo "x509userproxy = $proxy_file" >> $submit_file
 fi
 
-if [ "x$xtra_args" != "x" ]
-then
-  echo -e $xtra_args >> $submit_file
-fi
-
 if [ "x$req_mem" != "x" ]
 then
   echo "request_memory = $req_mem" >> $submit_file
@@ -282,19 +277,9 @@ else
 fi
 
 #local batch system-specific file output must be added to the submit file
-local_submit_attributes_file=${blah_libexec_directory}/condor_local_submit_attributes.sh
-if [ -r $local_submit_attributes_file ] ; then
-    echo \#\!/bin/sh > $tmp_req_file
-    if [ ! -z $req_file ] ; then
-        cat $req_file >> $tmp_req_file
-    fi
-    echo "source $local_submit_attributes_file" >> $tmp_req_file
-    chmod +x $tmp_req_file
-    $tmp_req_file >> $submit_file 2> /dev/null
-fi
-if [ -e $tmp_req_file ] ; then
-    rm -f $tmp_req_file
-fi
+bls_local_submit_attributes_file=${blah_libexec_directory}/condor_local_submit_attributes.sh
+
+bls_set_up_local_and_extra_args
 
 echo "queue 1" >> $submit_file
 

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -123,11 +123,11 @@ fi
 
 submit_file_environment="#"
 
-if [ "x$environment" != "x" ] ; then
+if [ "x$bls_opt_environment" != "x" ] ; then
 # Input format is suitable for bourne shell style assignment. Convert to
 # new condor format to avoid errors  when things like LS_COLORS (which 
 # has semicolons in it) get captured
-    eval "env_array=($environment)"
+    eval "env_array=($bls_opt_environment)"
     dq='"'
     sq="'"
     # escape single-quote and double-quote characters (by doubling them)

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -62,6 +62,8 @@ bls_test_input_files
 submit_file=$bls_tmp_file
 
 
+# XXX: is this (vvv) section covered in 'bls_setup_all_files'  ???
+
 if [ ! -z "$bls_opt_inputflstring" ] ; then
     i=0
     for file in `cat $bls_opt_inputflstring`; do
@@ -117,6 +119,9 @@ if [ ${#remap_files[@]} -gt 0 ] ; then
     done
     transfer_output_remaps="$transfer_output_remaps\""
 fi
+
+# XXX: is this (^^^) section covered in 'bls_setup_all_files'  ???
+
 
 # Convert input environment (old Condor or shell format as dictated by 
 # input args):

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -202,6 +202,8 @@ bls_set_up_local_and_extra_args
 echo "queue 1" >> $submit_file
 
 
+# bls_add_job_wrapper  # XXX appends to submit file; don't seem to want this.
+
 bls_save_submit
 
 ###############################################################

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -212,9 +212,8 @@ echo "queue 1" >> $submit_file
 # first param is the name of the queue and the second is the name of
 # the pool where the queue exists, i.e. a Collector's name.
 
-echo $bls_opt_queue | grep "/" >&/dev/null
 # If there is a "/" we need to split out the pool and queue
-if [ "$?" == "0" ]; then
+if [[ $bls_opt_queue = */* ]]; then
     pool=${bls_opt_queue#*/}
     bls_opt_queue=${bls_opt_queue%/*}
 fi

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -138,9 +138,9 @@ if [ "x$bls_opt_environment" != "x" ] ; then
     env_array=("${env_array[@]/%/$sq}")
     submit_file_environment="environment = \"${env_array[*]}\""
 else
-    if [ "x$envir" != "x" ] ; then
+    if [ "x$bls_opt_envir" != "x" ] ; then
 # Old Condor format (no double quotes in submit file)
-        submit_file_environment="environment = $envir"
+        submit_file_environment="environment = $bls_opt_envir"
     fi
 fi
 

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -240,7 +240,7 @@ if [ "$return_code" == "0" ] ; then
     blahp_jobID="condor/$jobID/$bls_opt_queue/$pool"
 
     if [ "x$job_registry" != "x" ]; then
-      ${blah_sbin_directory}/blah_job_registry_add "$blahp_jobID" "$jobID" 1 $now "$creamjobid" "$bls_opt_proxy_string" 0 "$bls_opt_proxy_subject"
+      ${blah_sbin_directory}/blah_job_registry_add "$blahp_jobID" "$jobID" 1 $now "$bls_opt_creamjobid" "$bls_opt_proxy_string" 0 "$bls_opt_proxy_subject"
     fi
 
     echo "BLAHP_JOBID_PREFIX$blahp_jobID"

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -158,7 +158,7 @@ fi
 
 cat > $submit_file << EOF
 universe = vanilla
-executable = $command
+executable = $bls_opt_the_command
 EOF
 
 if [ "x$proxy_file" != "x" ]

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -161,9 +161,9 @@ universe = vanilla
 executable = $bls_opt_the_command
 EOF
 
-if [ "x$proxy_file" != "x" ]
+if [ "x$bls_opt_proxy_string" != "x" ]
 then
-  echo "x509userproxy = $proxy_file" >> $submit_file
+  echo "x509userproxy = $bls_opt_proxy_string" >> $submit_file
 fi
 
 if [ "x$req_mem" != "x" ]
@@ -240,7 +240,7 @@ if [ "$return_code" == "0" ] ; then
     blahp_jobID="condor/$jobID/$queue/$pool"
 
     if [ "x$job_registry" != "x" ]; then
-      ${blah_sbin_directory}/blah_job_registry_add "$blahp_jobID" "$jobID" 1 $now "$creamjobid" "$proxy_file" 0 "$proxy_subject"
+      ${blah_sbin_directory}/blah_job_registry_add "$blahp_jobID" "$jobID" 1 $now "$creamjobid" "$bls_opt_proxy_string" 0 "$proxy_subject"
     fi
 
     echo "BLAHP_JOBID_PREFIX$blahp_jobID"
@@ -256,9 +256,9 @@ rm -f $submit_file
 # of limited proxy only.
 
 if [ "x$job_registry" == "x" ]; then
-    if [ -r "$proxy_file" -a -f "$proxy_file" ] ; then
+    if [ -r "$bls_opt_proxy_string" -a -f "$bls_opt_proxy_string" ] ; then
         [ -d "$proxy_dir" ] || mkdir $proxy_dir
-        ln -s $proxy_file $proxy_dir/$jobID.proxy.norenew
+        ln -s "$bls_opt_proxy_string" "$proxy_dir/$jobID.proxy.norenew"
     fi
 fi
 

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -37,7 +37,7 @@ original_args="$@"
 # Note: -s (stage command) s ignored as it is not relevant for Condor.
 
 # script debug flag: currently unused
-debug=no
+bls_opt_debug=no
 
 # number of MPI nodes: interpretted as a core count for vanilla universe
 mpinodes=1

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -36,15 +36,8 @@
 original_args="$@"
 # Note: -s (stage command) s ignored as it is not relevant for Condor.
 
-# script debug flag: currently unused
-bls_opt_debug=no
-
 # number of MPI nodes: interpretted as a core count for vanilla universe
 bls_opt_mpinodes=1
-
-# Name of local requirements file: currently unused
-bls_opt_req_file=""
-
 
 
 bls_parse_submit_options "$@"

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -92,11 +92,6 @@ do
     esac
 done
 
-if [ -z "$temp_dir"  ] ; then
-      curdir=`pwd`
-      temp_dir="$curdir"
-fi
-
 shift `expr $OPTIND - 1`
 arguments=$*
 
@@ -116,6 +111,8 @@ if [ "x$workdir" == "x" ]; then
     fi
 fi
 
+bls_setup_all_files
+
 if [ "x$workdir" != "x" ]; then
     cd $workdir
     if [ $? -ne 0 ]; then
@@ -129,12 +126,9 @@ fi
 # Create submit file
 ###############################################################
 
-submit_file=`mktemp -q $temp_dir/blahXXXXXX`
-if [ $? -ne 0 ]; then
-    echo "mktemp failed" >&2
-    echo Error
-    exit 1
-fi
+# set in bls_setup_all_files
+submit_file=$bls_tmp_file
+
 
 if [ ! -z "$inputflstring" ] ; then
     i=0
@@ -269,12 +263,6 @@ $submit_file_environment
 leave_in_queue = JobStatus == 4 && (CompletionDate =?= UNDEFINED || CompletionDate == 0 || ((CurrentTime - CompletionDate) < 1800))
 EOF
 
-# Set up temp file name for requirement passing
-if [ ! -z $req_file ] ; then
-   tmp_req_file=${req_file}-temp_req_script
-else
-   tmp_req_file=`mktemp $temp_dir/temp_req_script_XXXXXXXXXX`
-fi
 
 #local batch system-specific file output must be added to the submit file
 bls_local_submit_attributes_file=${blah_libexec_directory}/condor_local_submit_attributes.sh

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -148,10 +148,10 @@ fi
 # # so to get them back into Condor format we need to remove all the
 # # extra quotes. We do this by replacing '" "' with ' ' and stripping
 # # the leading and trailing "s.
-if [[ $arguments = '"'*'"' ]]; then
-  arguments=${arguments//'" "'/ }
-  arguments=${arguments/#'"'}
-  arguments=${arguments/%'"'}
+if [[ $bls_arguments = '"'*'"' ]]; then
+  bls_arguments=${bls_arguments//'" "'/ }
+  bls_arguments=${bls_arguments/#'"'}
+  bls_arguments=${bls_arguments/%'"'}
 fi
 
 cat > $submit_file << EOF
@@ -177,7 +177,7 @@ fi
 cat >> $submit_file << EOF
 request_cpus = $bls_opt_mpinodes
 # We insist on new style quoting in Condor
-arguments = $arguments
+arguments = $bls_arguments
 input = $bls_opt_stdin
 output = $bls_opt_stdout
 error = $bls_opt_stderr

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -62,9 +62,9 @@ bls_test_input_files
 submit_file=$bls_tmp_file
 
 
-if [ ! -z "$inputflstring" ] ; then
+if [ ! -z "$bls_opt_inputflstring" ] ; then
     i=0
-    for file in `cat $inputflstring`; do
+    for file in `cat $bls_opt_inputflstring`; do
 	input_files[$i]=$file
 	i=$((i+1))
     done

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -257,8 +257,8 @@ rm -f $submit_file
 
 if [ "x$job_registry" == "x" ]; then
     if [ -r "$bls_opt_proxy_string" -a -f "$bls_opt_proxy_string" ] ; then
-        [ -d "$proxy_dir" ] || mkdir $proxy_dir
-        ln -s "$bls_opt_proxy_string" "$proxy_dir/$jobID.proxy.norenew"
+        [ -d "$bls_proxy_dir" ] || mkdir "$bls_proxy_dir"
+        ln -s "$bls_opt_proxy_string" "$bls_proxy_dir/$jobID.proxy.norenew"
     fi
 fi
 

--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -212,20 +212,20 @@ echo "queue 1" >> $submit_file
 # first param is the name of the queue and the second is the name of
 # the pool where the queue exists, i.e. a Collector's name.
 
-echo $queue | grep "/" >&/dev/null
+echo $bls_opt_queue | grep "/" >&/dev/null
 # If there is a "/" we need to split out the pool and queue
 if [ "$?" == "0" ]; then
-    pool=${queue#*/}
-    queue=${queue%/*}
+    pool=${bls_opt_queue#*/}
+    bls_opt_queue=${bls_opt_queue%/*}
 fi
 
-if [ -z "$queue" ]; then
+if [ -z "$bls_opt_queue" ]; then
     target=""
 else
     if [ -z "$pool" ]; then
-	target="-name $queue"
+	target="-name $bls_opt_queue"
     else
-	target="-pool $pool -name $queue"
+	target="-pool $pool -name $bls_opt_queue"
     fi
 fi
 
@@ -237,7 +237,7 @@ return_code=$?
 
 if [ "$return_code" == "0" ] ; then
     jobID=`echo $full_result | awk '{print $8}' | tr -d '.'`
-    blahp_jobID="condor/$jobID/$queue/$pool"
+    blahp_jobID="condor/$jobID/$bls_opt_queue/$pool"
 
     if [ "x$job_registry" != "x" ]; then
       ${blah_sbin_directory}/blah_job_registry_add "$blahp_jobID" "$jobID" 1 $now "$creamjobid" "$bls_opt_proxy_string" 0 "$bls_opt_proxy_subject"


### PR DESCRIPTION
See [SOFTWARE-3994](https://opensciencegrid.atlassian.net/browse/SOFTWARE-3994) for background.

The other batch systems' `*_submit.sh` scripts recognize a `blah_debug_save_submit_info` environment variable, which when set externally will be used as a directory to dump debugging info - primarily a copy of the submit file.

This is handled with a call to the `bls_save_submit` shell function from `blah_common_submit_functions.sh`, which `condor_submit.sh` up to this point never sourced.

There is a lot of overlapping code between condor_submit.sh and blah_common_submit_functions.sh, and taking the step of sourcing the common code seemed like a good opportunity to standardize on using the common functions rather than all the inline cruft in condor_submit.sh.  So be it, we said.

Turns out there were a lot of little differences, in ordering of things and of variable naming, which needed to be updated as well to be able to use the common code.

There were a few particularly offensive bash anti-patterns that, since i was touching them anyway, i felt compelled to rework a bit.

But otherwise the main points here are including the common submit functions, replacing existing code with those function calls, fixing variable names to match what's used in the common code, and finally adding a call to `bls_save_submit` to save the debugging files.

I also add a few notes about things that look like they might be able to be replaced with calls to common code functions, but don't seem to have exactly the same semantics, so at this point i've left them as they are.

All of this is untested at this point but in any case any feedback is welcome.

Out of habit i almost want to apologize for there being so many commits in this PR, but the fact is i put a lot of work into separating this out into smaller commits that can be reasoned about more easily; because the entire changeset taken as a whole is unweildy even for me as its author.