### PR TITLE
Ignore proxy symlink errors on refresh when not needed.

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2001,7 +2001,12 @@ cmd_renew_proxy(void *args)
 	jobStatus=get_status_and_old_proxy(use_mapping, jobDescr, proxyFileName, argv + CMD_RENEW_PROXY_ARGS + 1, &old_proxy, &workernode, &error_string);
 	old_proxy_len = -1;
 	if (old_proxy != NULL) old_proxy_len = strlen(old_proxy);
-	if ((jobStatus < 0) || (old_proxy == NULL) || (old_proxy_len <= 0))
+	if (!use_mapping && disable_limited_proxy && disable_wn_proxy_renewal)
+	{
+		/* Nothing needs to be done with the proxy */
+		resultLine = make_message("%s 0 Proxy\\ renewed", reqId);
+	}
+	else if ((jobStatus < 0) || (old_proxy == NULL) || (old_proxy_len <= 0))
 	{
 		resultLine = make_message("%s 1 Cannot\\ locate\\ old\\ proxy:\\ %s", reqId, error_string);
 		if (BLAH_DYN_ALLOCATED(error_string)) free(error_string);


### PR DESCRIPTION
On a BLAH_JOB_REFRESH_PROXY command, ignore errors in finding the
symlink to the old proxy under $(HOME)/.blah_jobproxy_dir/ if it's not
needed. The symlink is needed only when switching uids, creating a
limited proxy, or forwarding the proxy to the worker node.
HTCondor gittrac #7825