### PR TITLE
Improve multicore support for Slurm. HTCONDOR-166

### DIFF
--- a/src/scripts/slurm_submit.sh
+++ b/src/scripts/slurm_submit.sh
@@ -78,12 +78,40 @@ fi
 [ -z "$bls_opt_queue" ] || grep -q "^#SBATCH -p" $bls_tmp_file || echo "#SBATCH -p $bls_opt_queue" >> $bls_tmp_file
 [ -z "$cluster_name" ] || grep -q "^#SBATCH -M" $bls_tmp_file || echo "#SBATCH -M $cluster_name" >> $bls_tmp_file
 
-# Simple support for multi-cpu attributes
-if [[ $bls_opt_mpinodes -gt 1 ]] ; then
-  echo "#SBATCH --nodes=1" >> $bls_tmp_file
-  echo "#SBATCH --ntasks=1" >> $bls_tmp_file
-  echo "#SBATCH --cpus-per-task=$bls_opt_mpinodes" >> $bls_tmp_file
+# Extended support for MPI attributes
+if [ "x$bls_opt_wholenodes" == "xyes" ] ; then
+  bls_opt_hostsmpsize=${bls_opt_hostsmpsize:-1}
+  if [[ ! -z "$bls_opt_smpgranularity" ]] ; then
+    if [[ -z "$bls_opt_hostnumber" ]] ; then
+      echo "#SBATCH -N 1" >> $bls_tmp_file
+      echo "#SBATCH --ntasks-per-node $bls_opt_smpgranularity" >> $bls_tmp_file
+    else
+      echo "#SBATCH -N $bls_opt_hostnumber" >> $bls_tmp_file
+      echo "#SBATCH --ntasks-per-node $bls_opt_smpgranularity" >> $bls_tmp_file
+    fi
+    echo "#SBATCH --exclusive" >> $bls_tmp_file
+  else
+    if [[ ! -z "$bls_opt_hostnumber" ]] ; then
+      if [[ $bls_opt_mpinodes -gt 0 ]] ; then
+        echo "#SBATCH -N $bls_opt_hostnumber" >> $bls_tmp_file
+        echo "#SBATCH -n $bls_opt_mpinodes" >> $bls_tmp_file
+      else
+        echo "#SBATCH -N $bls_opt_hostnumber" >> $bls_tmp_file
+      fi
+      echo "#SBATCH --exclusive" >> $bls_tmp_file
+    fi
+  fi
+else
+  if [[ ! -z "$bls_opt_mpinodes" ]] ; then
+    echo "#SBATCH -n $bls_opt_mpinodes" >> $bls_tmp_file
+  fi
+  if [[ ! -z "$bls_opt_smpgranularity" ]] ; then
+    echo "#SBATCH --ntasks-per-node $bls_opt_smpgranularity" >> $bls_tmp_file
+  elif [[ ! -z "$bls_opt_hostnumber" ]] ; then
+    echo "#SBATCH -N $bls_opt_hostnumber" >> $bls_tmp_file
+  fi
 fi
+# --- End of MPI directives
 
 # add GPU support
 [ -z "$bls_opt_gpunumber" ] || [ -z "$bls_opt_gpumodel" ] || echo "#SBATCH --gres=gpu:${bls_opt_gpumodel}:${bls_opt_gpunumber}" >> $bls_tmp_file


### PR DESCRIPTION
Add support for blahp's full set of multicore job attribtues on Slurm,
ported from upstream.

This is a modified form of code written by the following people:
  David Rebatto <david.rebatto@mi.infn.it>
  Pavel Demin <pavel-demin@outlook.com>