### PR TITLE
Pylint the files directly instead of trying module auto-detection

### DIFF
--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -25,4 +25,4 @@ jobs:
         pip --cache-dir ~/pip-cache install pylint
     - name: Run Pylint
       run: |
-        cd ./src/scripts/ && pylint --errors-only scripts
+        cd ./src/scripts/ && pylint --errors-only *.py


### PR DESCRIPTION
Otherwise we get `blah` import errors: https://github.com/brianhlin/BLAH/runs/2239867346?check_suite_focus=true