### PR TITLE
Fix data type for GPUNumber and MICNumber. HTCONDOR-528

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1303,8 +1303,8 @@ cmd_submit_job(void *args)
 	    (set_cmd_string_option(&command, cad, "Iwd",        "-w", NO_QUOTE)      == C_CLASSAD_OUT_OF_MEMORY) ||
 //	    (set_cmd_string_option(&command, cad, "Env",        "-v", SINGLE_QUOTE)  == C_CLASSAD_OUT_OF_MEMORY) ||
 	    (set_cmd_string_option(&command, cad, "Queue",      "-q", NO_QUOTE)      == C_CLASSAD_OUT_OF_MEMORY) ||
-	    (set_cmd_string_option(&command, cad, "MICNumber",  "-P", INT_NOQUOTE)   == C_CLASSAD_OUT_OF_MEMORY) ||
-	    (set_cmd_string_option(&command, cad, "GPUNumber",  "-g", INT_NOQUOTE)   == C_CLASSAD_OUT_OF_MEMORY) ||
+	    (set_cmd_int_option   (&command, cad, "MICNumber",  "-P", INT_NOQUOTE)   == C_CLASSAD_OUT_OF_MEMORY) ||
+	    (set_cmd_int_option   (&command, cad, "GPUNumber",  "-g", INT_NOQUOTE)   == C_CLASSAD_OUT_OF_MEMORY) ||
 	    (set_cmd_string_option(&command, cad, "GPUMode",    "-G", NO_QUOTE)      == C_CLASSAD_OUT_OF_MEMORY) ||
 	    (set_cmd_string_option(&command, cad, "GPUModel",   "-M", SINGLE_QUOTE)  == C_CLASSAD_OUT_OF_MEMORY) ||
 	    (set_cmd_int_option   (&command, cad, "NodeNumber", "-n", INT_NOQUOTE)   == C_CLASSAD_OUT_OF_MEMORY) ||


### PR DESCRIPTION
When looking up GPUNumber and MICNumber in the job ad, the value
type should be integer, not string.