### PR TITLE
Add build option to disable use of Globus libraries. HTCONDOR-345

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -236,18 +236,25 @@ AC_SUBST(DISTTAR)
 
 AC_CLASSADS([], AC_MSG_RESULT(["CLASSADS ok"]), AC_MSG_ERROR(["CLASSADS not found"]))
 
-AC_GLOBUS([], have_globus=yes, have_globus=no)
+AC_ARG_WITH([globus], AS_HELP_STRING([--without-globus], [Disable use of Globus libraries]))
 
-if test $have_globus = no; then
-  have_globus=yes
-  PKG_CHECK_MODULES(GLOBUS_GSI_CRED, globus-gsi-credential, , have_globus=no)
-  PKG_CHECK_MODULES(GLOBUS_GSI_PROXY, globus-gsi-proxy-core, , have_globus=no)
-  PKG_CHECK_MODULES(GLOBUS_GSI_UTILS, globus-gsi-cert-utils, , have_globus=no)
-  PKG_CHECK_MODULES(GLOBUS_GSS_ASSIST, globus-gss-assist, , have_globus=no)
-  PKG_CHECK_MODULES(GLOBUS_GSI_SYSCFG, globus-gsi-sysconfig, , have_globus=no)
-  PKG_CHECK_MODULES(GLOBUS_GSSAPI_GSI, globus-gssapi-gsi, , have_globus=no)
+if test "x$with_globus" != "xno"; then
+  AC_GLOBUS([], have_globus=yes, have_globus=no)
+
+  if test $have_globus = no; then
+    have_globus=yes
+    PKG_CHECK_MODULES(GLOBUS_GSI_CRED, globus-gsi-credential, , have_globus=no)
+    PKG_CHECK_MODULES(GLOBUS_GSI_PROXY, globus-gsi-proxy-core, , have_globus=no)
+    PKG_CHECK_MODULES(GLOBUS_GSI_UTILS, globus-gsi-cert-utils, , have_globus=no)
+    PKG_CHECK_MODULES(GLOBUS_GSS_ASSIST, globus-gss-assist, , have_globus=no)
+    PKG_CHECK_MODULES(GLOBUS_GSI_SYSCFG, globus-gsi-sysconfig, , have_globus=no)
+    PKG_CHECK_MODULES(GLOBUS_GSSAPI_GSI, globus-gssapi-gsi, , have_globus=no)
+  fi
+  AC_MSG_RESULT(["GLOBUS found: $have_globus"])
+else
+  have_globus=no
+  AC_MSG_RESULT(["Compiling without Globus"])
 fi
-AC_MSG_RESULT(["GLOBUS found: $have_globus"])
 AM_CONDITIONAL([HAVE_GLOBUS], [test "x$bprserver" == "xyes" -a "x$have_globus" == "xyes"])
 
 dnl Temporarily built with no optimisation

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -31,20 +31,23 @@
 #    limitations under the License.
 #
 
-INCLUDES = -I. $(CLASSAD_CFLAGS) \
+if HAVE_GLOBUS
+GLOBUS_CFLAGS = -DHAVE_GLOBUS
            $(GLOBUS_GSI_CRED_CFLAGS) \
            $(GLOBUS_GSI_PROXY_CFLAGS) \
            $(GLOBUS_GSI_UTILS_CFLAGS) \
            $(GLOBUS_GSS_ASSIST_CFLAGS) \
            $(GLOBUS_GSI_SYSCFG_CFLAGS) 
-
-SUBDIRS = scripts
-
-if HAVE_GLOBUS
 GLOBUS_EXECS = BPRclient BPRserver
 else
+GLOBUB_CFLAGS =
 GLOBUS_EXECS =
 endif
+
+INCLUDES = -I. $(CLASSAD_CFLAGS) \
+           $(GLOBUS_CFLAGS)
+
+SUBDIRS = scripts
 
 sbin_PROGRAMS = blahpd_daemon blah_job_registry_add blah_job_registry_lkup blah_job_registry_scan_by_subject blah_check_config blah_job_registry_dump blah_job_registry_purge
 bin_PROGRAMS = blahpd


### PR DESCRIPTION
Add --with[out]-globus option to configure (default is with), with
attendent source code macro HAVE_GLOBUS. If run-time configuration of
the blahp requires proxy file manipulation, the operations will fail.