### PR TITLE
Make BatchExtraSubmitArgs more flexible. HTCONDOR-526

### DIFF
--- a/src/scripts/blah_common_submit_functions.sh
+++ b/src/scripts/blah_common_submit_functions.sh
@@ -842,7 +842,11 @@ function bls_set_up_local_and_extra_args ()
   fi
   
   if [ ! -z "$bls_opt_xtra_args" ] ; then
-      echo -e $bls_opt_xtra_args >> $bls_tmp_file 2> /dev/null
+      prefix=
+      if echo "$bls_opt_xtra_args" | grep -q -v "^$bls_submit_args_prefix" ; then
+          prefix="$bls_submit_args_prefix "
+      fi
+      echo -e ${prefix}${bls_opt_xtra_args} >> $bls_tmp_file 2> /dev/null
   fi
 }
 

--- a/src/scripts/lsf_submit.sh
+++ b/src/scripts/lsf_submit.sh
@@ -47,6 +47,8 @@
 
 . `dirname $0`/blah_common_submit_functions.sh
 
+bls_submit_args_prefix="#BSUB"
+
 conffile=$lsf_confpath/lsf.conf
 
 lsf_base_path=`cat $conffile|grep LSB_SHAREDIR| awk -F"=" '{ print $2 }'`

--- a/src/scripts/pbs_submit.sh
+++ b/src/scripts/pbs_submit.sh
@@ -44,6 +44,8 @@
 
 . `dirname $0`/blah_common_submit_functions.sh
 
+bls_submit_args_prefix="#PBS"
+
 logpath=${pbs_spoolpath}/server_logs
 if [ ! -d $logpath -o ! -x $logpath ]; then
   if [ -x "${pbs_binpath}/tracejob" ]; then

--- a/src/scripts/sge_submit.sh
+++ b/src/scripts/sge_submit.sh
@@ -36,6 +36,8 @@
 
 . `dirname $0`/blah_common_submit_functions.sh
 
+bls_submit_args_prefix='#$'
+
 if [ -z "$sge_rootpath" ]; then sge_rootpath="/usr/local/sge/pro"; fi
 if [ -r "$sge_rootpath/${sge_cellname:-default}/common/settings.sh" ]
 then

--- a/src/scripts/slurm_submit.sh
+++ b/src/scripts/slurm_submit.sh
@@ -32,6 +32,8 @@
 slurm_std_storage=${slurm_std_storage:-/dev/null}
 slurm_binpath=${slurm_binpath:-/usr/bin}
 
+bls_submit_args_prefix="#SBATCH"
+
 bls_parse_submit_options "$@"
 
 bls_setup_all_files


### PR DESCRIPTION
If BatchExtraSubmitArgs doesn't begin with the batch system's prefix
(e.g. '#SBATCH'), insert it when writing the submit script.