### PR TITLE
Naming output files causing overwriting. HTCONDOR-553

### DIFF
--- a/src/scripts/blah_common_submit_functions.sh
+++ b/src/scripts/blah_common_submit_functions.sh
@@ -609,6 +609,8 @@ function bls_setup_all_files ()
           if [ ! -z $xfile  ] ; then
               if [ ! -z "$bls_opt_outputflstringremap" ] ; then
                   read xfileremap <&6
+              else
+                  xfileremap=""
               fi
 
               if [ -z $xfileremap ] ; then


### PR DESCRIPTION
When TransferOutputFiles is given, and the blahp scripts copy/move the
files, the same filename is used as the destination for all
copying/moving. This causes most output files to be missing from the job
sandbox.
In function bls_setup_all_files() in blah_common_submit_functions.sh,
the variable xfileremap needs to be set on every loop iteration.